### PR TITLE
Fix VIBE_2 to VIBE_4

### DIFF
--- a/src/main/java/com/sst/alexatempurpedic/BedCommand.java
+++ b/src/main/java/com/sst/alexatempurpedic/BedCommand.java
@@ -48,9 +48,9 @@ public enum BedCommand {
      * Vibration Setting #1 - #4
      */
     BED_VIBE_1("v1", "Vibration Setting 1", "33053203948D007861"),
-    BED_VIBE_2("v2", "Vibration Setting 2", "33053203948D007860"),
-    BED_VIBE_3("v3", "Vibration Setting 3", "33053203948D007863"),
-    BED_VIBE_4("v4", "Vibration Setting 4", "33053203948D007862");
+    BED_VIBE_2("v2", "Vibration Setting 2", "33053203948D017860"),
+    BED_VIBE_3("v3", "Vibration Setting 3", "33053203948D027863"),
+    BED_VIBE_4("v4", "Vibration Setting 4", "33053203948D037862");
     
     // The bed position in short form which is in LIST_OF_POSITIONS 
     private final String position;


### PR DESCRIPTION
I was using your codes for use in homeassistant.  VIBE_1 and OFF worked, but 2-4 didn't work.  After packet sniffing, I noticed that the third-to-last hex digit was also changing, whereas you had it as 00 for all 4 commands.  This should fix it.  I tested on my tempur bed to make sure the codes are right.  Please let me know if it now works for you too.